### PR TITLE
Split comma separated list of hostnames in top file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
-FROM python:3-onbuild
+FROM python:3-alpine
+
+COPY requirements.txt /root/
+RUN pip install --no-cache-dir -r /root/requirements.txt
 
 RUN mkdir -p /mnt/git
 

--- a/salt-git-diff.py
+++ b/salt-git-diff.py
@@ -94,7 +94,9 @@ def top_records_containing_states(top, match_states):
                     match = True
             # end for state in states
             if match:
-                matching_records.append(key)
+                # A top file match can be a comma separated list of hostnames
+                records = key.split(sep=',')
+                matching_records.extend(records)
     # end for key, states in top
     return matching_records
 


### PR DESCRIPTION
If the top file selector is a list of hostnames, like
'foo.example.com,bar.example.com', this change should do as expected and
add the individial hostnames to the returned set.

Also sneakily make a much smaller alpine image.